### PR TITLE
Spec out nullability for Spark SDK

### DIFF
--- a/Pod/Classes/SDK/SparkAccessToken.h
+++ b/Pod/Classes/SDK/SparkAccessToken.h
@@ -19,21 +19,28 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class SparkAccessToken;
 
 @protocol SparkAccessTokenDelegate <NSObject>
--(void)SparkAccessToken:(SparkAccessToken *)accessToken didExpireAt:(NSDate *)date;
+
+@required
+-(void)sparkAccessToken:(SparkAccessToken *)accessToken didExpireAt:(NSDate *)date;
+
 @end
 
 @interface SparkAccessToken : NSObject
+
 /**
  *  Access token string to be used when calling cloud API
  */
-@property (nonatomic, strong, readonly) NSString *accessToken;
+@property (nonatomic, strong, nullable, readonly) NSString *accessToken;
+
 /**
  *  Delegate to receive didExpireAt method call whenever a token is detected as expired
  */
-@property (nonatomic, weak) id<SparkAccessTokenDelegate> delegate;
+@property (nonatomic, nullable, weak) id<SparkAccessTokenDelegate> delegate;
 
 /**
  *  Initialze SparkAccessToken class with new session
@@ -42,14 +49,14 @@
  *
  *  @return New SparkAccessToken instance
  */
--(instancetype)initWithNewSession:(NSDictionary *)loginResponseDict;
+-(nullable instancetype)initWithNewSession:(NSDictionary *)loginResponseDict;
 
 /**
  *  Initialize SparkAccessToken from existing session stored in keychain
  *
  *  @return A SparkAccessToken instance in case session is stored in keychain and token has not expired, nil if not
  */
--(instancetype)initWithSavedSession;
+-(nullable instancetype)initWithSavedSession;
 
 -(instancetype)init __attribute__((unavailable("Must use initWithNewSession: or initWithSavedSession:")));
 
@@ -59,3 +66,5 @@
 -(void)removeSession;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Pod/Classes/SDK/SparkAccessToken.m
+++ b/Pod/Classes/SDK/SparkAccessToken.m
@@ -11,6 +11,8 @@
 #import <AFNetworking/AFHTTPSessionManager.h>
 #import "SparkCloud.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 NSString *const kSparkAccessTokenKeychainEntry = @"io.spark.api.Keychain.AccessToken";
 NSString *const kSparkAccessTokenExpiryDateKey = @"kSparkAccessTokenExpiryDateKey";
 NSString *const kSparkAccessTokenStringKey = @"kSparkAccessTokenStringKey";
@@ -19,14 +21,16 @@ NSString *const kSparkAccessTokenStringKey = @"kSparkAccessTokenStringKey";
 #define ACCESS_TOKEN_EXPIRY_MARGIN  0
 
 @interface SparkAccessToken()
+
 @property (nonatomic, strong) NSDate *expiryDate;
 @property (nonatomic, strong) NSTimer *expiryTimer;
-@property (nonatomic, strong) NSString *accessToken;
+@property (nonatomic, strong, readwrite) NSString *accessToken;
+
 @end
 
 @implementation SparkAccessToken
 
--(instancetype)initWithNewSession:(NSDictionary *)loginResponseDict
+-(nullable instancetype)initWithNewSession:(NSDictionary *)loginResponseDict
 {
     self = [super init];
     if (self)
@@ -62,15 +66,7 @@ NSString *const kSparkAccessTokenStringKey = @"kSparkAccessTokenStringKey";
     return nil;
 }
 
-
--(void)accessTokenExpired:(NSTimer *)timer
-{
-    [self.expiryTimer invalidate];
-    [self.delegate SparkAccessToken:self didExpireAt:self.expiryDate];
-}
-
-
--(instancetype)initWithSavedSession
+-(nullable instancetype)initWithSavedSession
 {
     self = [super init];
     if (self)
@@ -115,7 +111,7 @@ NSString *const kSparkAccessTokenStringKey = @"kSparkAccessTokenStringKey";
 }
 
 
--(NSString *)accessToken
+-(nullable NSString *)accessToken
 {
     // always return only a non-expired access token
     NSTimeInterval ti = [self.expiryDate timeIntervalSinceNow];
@@ -133,6 +129,11 @@ NSString *const kSparkAccessTokenStringKey = @"kSparkAccessTokenStringKey";
     self.accessToken = nil;
 }
 
+-(void)accessTokenExpired:(NSTimer *)timer
+{
+    [self.expiryTimer invalidate];
+    [self.delegate sparkAccessToken:self didExpireAt:self.expiryDate];
+}
 
 -(void)dealloc
 {
@@ -140,3 +141,5 @@ NSString *const kSparkAccessTokenStringKey = @"kSparkAccessTokenStringKey";
 }
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Pod/Classes/SDK/SparkCloud.h
+++ b/Pod/Classes/SDK/SparkCloud.h
@@ -21,22 +21,25 @@
 #import "SparkDevice.h"
 #import "SparkEvent.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 extern NSString *const kSparkAPIBaseURL;
 
 @interface SparkCloud : NSObject
 
 /**
- *  Currently loggeed in user name, nil if no session exists
+ *  Currently logged in user name, nil if no valid session
  */
-@property (nonatomic, strong, readonly) NSString* loggedInUsername;
+@property (nonatomic, strong, nullable, readonly) NSString* loggedInUsername;
 @property (nonatomic, readonly) BOOL isLoggedIn;
 /**
- *  Current session access token string
+ *  Current session access token string, nil if not logged in
  */
-@property (nonatomic, strong, readonly) NSString *accessToken;
+@property (nonatomic, strong, nullable, readonly) NSString *accessToken;
 
-@property (nonatomic, strong) NSString *OAuthClientId;
-@property (nonatomic, strong) NSString *OAuthClientSecret;
+@property (nonatomic, null_resettable, strong) NSString *OAuthClientId;
+@property (nonatomic, null_resettable, strong) NSString *OAuthClientSecret;
+
 /**
  *  Singleton instance of SparkCloud class
  *
@@ -56,7 +59,9 @@ extern NSString *const kSparkAPIBaseURL;
  *  @param password   Password
  *  @param completion Completion block will be called when login finished, NSError object will be passed in case of an error, nil if success
  */
--(NSURLSessionDataTask *)loginWithUser:(NSString *)user password:(NSString *)password completion:(void (^)(NSError *error))completion;
+-(NSURLSessionDataTask *)loginWithUser:(NSString *)user
+                              password:(NSString *)password
+                            completion:(nullable SparkCompletionBlock)completion;
 
 /**
  *  Sign up with new account credentials to Spark cloud
@@ -65,7 +70,9 @@ extern NSString *const kSparkAPIBaseURL;
  *  @param password   Required password
  *  @param completion Completion block will be called when sign-up finished, NSError object will be passed in case of an error, nil if success
  */
--(NSURLSessionDataTask *)signupWithUser:(NSString *)user password:(NSString *)password completion:(void (^)(NSError *error))completion;
+-(NSURLSessionDataTask *)signupWithUser:(NSString *)user
+                               password:(NSString *)password
+                             completion:(nullable SparkCompletionBlock)completion;
 
 
 /**
@@ -76,7 +83,10 @@ extern NSString *const kSparkAPIBaseURL;
  *  @param orgSlug    Organization string to include in cloud API endpoint URL
  *  @param completion Completion block will be called when sign-up finished, NSError object will be passed in case of an error, nil if success
  */
--(NSURLSessionDataTask *)signupWithCustomer:(NSString *)email password:(NSString *)password orgSlug:(NSString *)orgSlug completion:(void (^)(NSError *))completion;
+-(nullable NSURLSessionDataTask *)signupWithCustomer:(NSString *)email
+                                            password:(NSString *)password
+                                             orgSlug:(NSString *)orgSlug
+                                          completion:(nullable SparkCompletionBlock)completion;
 
 /**
  *  Logout user, remove session data
@@ -90,8 +100,11 @@ extern NSString *const kSparkAPIBaseURL;
  *  @param email      user email
  *  @param completion Completion block with NSError object if failure, nil if success
  */
--(NSURLSessionDataTask *)requestPasswordResetForCustomer:(NSString *)orgSlug email:(NSString *)email completion:(void(^)(NSError *))completion;
--(NSURLSessionDataTask *)requestPasswordResetForUser:(NSString *)email completion:(void(^)(NSError *))completion;
+-(NSURLSessionDataTask *)requestPasswordResetForCustomer:(NSString *)orgSlug
+                                                   email:(NSString *)email
+                                              completion:(nullable SparkCompletionBlock)completion;
+-(NSURLSessionDataTask *)requestPasswordResetForUser:(NSString *)email
+                                          completion:(nullable SparkCompletionBlock)completion;
 
 #pragma mark Device management functions
 // --------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -104,7 +117,7 @@ extern NSString *const kSparkAPIBaseURL;
  *
  *  @param completion Completion block with the device instances array in case of success or with NSError object if failure
  */
--(NSURLSessionDataTask *)getDevices:(void (^)(NSArray *sparkDevices, NSError *error))completion;
+-(NSURLSessionDataTask *)getDevices:(nullable void (^)(NSArray * _Nullable sparkDevices, NSError * _Nullable error))completion;
 
 /**
  *  Get a specific device instance by its deviceID. If the device is offline the instance will contain only partial information the cloud has cached, 
@@ -113,7 +126,8 @@ extern NSString *const kSparkAPIBaseURL;
  *  @param deviceID   required deviceID
  *  @param completion Completion block with first arguemnt as the device instance in case of success or with second argument NSError object if operation failed
  */
--(NSURLSessionDataTask *)getDevice:(NSString *)deviceID completion:(void (^)(SparkDevice *, NSError *))completion;
+-(NSURLSessionDataTask *)getDevice:(NSString *)deviceID
+                        completion:(nullable void (^)(SparkDevice * _Nullable device, NSError * _Nullable error))completion;
 
 // Not available yet
 //-(void)publishEvent:(NSString *)eventName data:(NSData *)data;
@@ -124,14 +138,15 @@ extern NSString *const kSparkAPIBaseURL;
  *  @param deviceID   required deviceID
  *  @param completion Completion block with NSError object if failure, nil if success
  */
--(NSURLSessionDataTask *)claimDevice:(NSString *)deviceID completion:(void(^)(NSError *))completion;
+-(NSURLSessionDataTask *)claimDevice:(NSString *)deviceID
+                          completion:(nullable SparkCompletionBlock)completion;
 
 /**
  *  Get a short-lived claiming token for transmitting to soon-to-be-claimed device in soft AP setup process
  *
  *  @param completion Completion block with claimCode string returned (48 random bytes base64 encoded to 64 ASCII characters), second argument is a list of the devices currently claimed by current session user and third is NSError object for failure, nil if success
  */
--(NSURLSessionDataTask *)generateClaimCode:(void(^)(NSString *claimCode, NSArray *userClaimedDeviceIDs, NSError *error))completion;
+-(NSURLSessionDataTask *)generateClaimCode:(nullable void(^)(NSString * _Nullable claimCode, NSArray * _Nullable userClaimedDeviceIDs, NSError * _Nullable error))completion;
 
 
 /**
@@ -142,7 +157,10 @@ extern NSString *const kSparkAPIBaseURL;
  *
  *  @param completion Completion block with claimCode string returned (48 random bytes base64 encoded to 64 ASCII characters), second argument is a list of the devices currently claimed by current session user and third is NSError object for failure, nil if success
  */
--(NSURLSessionDataTask *)generateClaimCodeForOrganization:(NSString *)orgSlug andProduct:(NSString *)productSlug withActivationCode:(NSString *)activationCode completion:(void(^)(NSString *claimCode, NSArray *userClaimedDeviceIDs, NSError *error))completion;
+-(NSURLSessionDataTask *)generateClaimCodeForOrganization:(NSString *)orgSlug
+                                               andProduct:(NSString *)productSlug
+                                       withActivationCode:(NSString *)activationCode
+                                               completion:(nullable void(^)(NSString *_Nullable claimCode, NSArray * _Nullable userClaimedDeviceIDs, NSError * _Nullable error))completion;
 
 
 #pragma mark Events subsystem functions
@@ -157,7 +175,7 @@ extern NSString *const kSparkAPIBaseURL;
  *  @param eventName    Filter only events that match name eventName, if nil is passed any event will trigger eventHandler
  *  @return eventListenerID function will return an id type object as the eventListener registration unique ID - keep and pass this object to the unsubscribe method in order to remove this event listener
  */
--(id)subscribeToAllEventsWithPrefix:(NSString *)eventNamePrefix handler:(SparkEventHandler)eventHandler;
+-(nullable id)subscribeToAllEventsWithPrefix:(nullable NSString *)eventNamePrefix handler:(nullable SparkEventHandler)eventHandler;
 /**
  *  Subscribe to all events, public and private, published by devices one owns
  *
@@ -165,7 +183,7 @@ extern NSString *const kSparkAPIBaseURL;
  *  @param eventNamePrefix  Filter only events that match name eventNamePrefix, for exact match pass whole string, if nil/empty string is passed any event will trigger eventHandler
  *  @return eventListenerID function will return an id type object as the eventListener registration unique ID - keep and pass this object to the unsubscribe method in order to remove this event listener
  */
--(id)subscribeToMyDevicesEventsWithPrefix:(NSString *)eventNamePrefix handler:(SparkEventHandler)eventHandler;
+-(nullable id)subscribeToMyDevicesEventsWithPrefix:(nullable NSString *)eventNamePrefix handler:(nullable SparkEventHandler)eventHandler;
 
 /**
  *  Subscribe to events from one specific device. If the API user has the device claimed, then she will receive all events, public and private, published by that device. 
@@ -176,7 +194,7 @@ extern NSString *const kSparkAPIBaseURL;
  *  @param eventHandler     Event handler function that accepts the event payload dictionary and an NSError object in case of an error
  *  @return eventListenerID function will return an id type object as the eventListener registration unique ID - keep and pass this object to the unsubscribe method in order to remove this event listener
  */
--(id)subscribeToDeviceEventsWithPrefix:(NSString *)eventNamePrefix deviceID:(NSString *)deviceID handler:(SparkEventHandler)eventHandler;
+-(nullable id)subscribeToDeviceEventsWithPrefix:(nullable NSString *)eventNamePrefix deviceID:(NSString *)deviceID handler:(nullable SparkEventHandler)eventHandler;
 
 /**
  *  Unsubscribe from event/events.
@@ -195,7 +213,13 @@ extern NSString *const kSparkAPIBaseURL;
  *  @param ttl          TTL stands for Time To Live. It it the number of seconds that the event data is relevant and meaningful. For example, an outdoor temperature reading with a precision of integer degrees Celsius might have a TTL of somewhere between 600 (10 minutes) and 1800 (30 minutes).
  *                      The geolocation of a large piece of farm equipment that remains stationary most of the time but may be moved to a different field once in a while might have a TTL of 86400 (24 hours). After the TTL has passed, the information can be considered stale or out of date.
  */
--(NSURLSessionDataTask *)publishEventWithName:(NSString *)eventName data:(NSString *)data isPrivate:(BOOL)isPrivate ttl:(NSUInteger)ttl completion:(void (^)(NSError *))completion;
+-(NSURLSessionDataTask *)publishEventWithName:(NSString *)eventName
+                                         data:(NSString *)data
+                                    isPrivate:(BOOL)isPrivate
+                                          ttl:(NSUInteger)ttl
+                                   completion:(nullable SparkCompletionBlock)completion;
 
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Pod/Classes/SDK/SparkEvent.h
+++ b/Pod/Classes/SDK/SparkEvent.h
@@ -7,6 +7,9 @@
 //
 
 #import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  *  Spark event handler function which receives two arguements
  *
@@ -15,12 +18,12 @@
  */
 @class SparkEvent;
 
-typedef void (^SparkEventHandler)(SparkEvent *event, NSError *error);
+typedef void (^SparkEventHandler)(SparkEvent * _Nullable event, NSError * _Nullable error);
 
 @interface SparkEvent : NSObject
 
 @property (nonatomic, strong) NSString *deviceID;   // Event published by this device ID
-@property (nonatomic, strong) NSString *data;       // Event string payload
+@property (nonatomic, nullable, strong) NSString *data;       // Event string payload
 @property (nonatomic, strong) NSString *event;      // Event name
 @property (nonatomic, strong) NSDate *time;         // Event "published at" time/dat
 @property (nonatomic) NSInteger ttl;                // Event time to live
@@ -28,3 +31,5 @@ typedef void (^SparkEventHandler)(SparkEvent *event, NSError *error);
 -(instancetype)initWithEventDict:(NSDictionary *)eventDict;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Pod/Classes/SDK/SparkEvent.m
+++ b/Pod/Classes/SDK/SparkEvent.m
@@ -8,12 +8,14 @@
 
 #import "SparkEvent.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @implementation SparkEvent
+
 -(instancetype)initWithEventDict:(NSDictionary *)eventDict
 {
     if (self = [super init])
-    {
-        
+    {        
         self.deviceID = eventDict[@"coreid"];
         self.data = eventDict[@"data"];
         self.event = eventDict[@"event"];
@@ -29,11 +31,14 @@
     }
     
     return self;
-    
 }
 
 -(NSString *)description
 {
-    return [NSString stringWithFormat:@"<Event: %@, DeviceID: %@, Data: %@, Time: %@, TTL: %ld>",self.event,self.deviceID,self.data,self.time,(long)self.ttl];
+    return [NSString stringWithFormat:@"<Event: %@, DeviceID: %@, Data: %@, Time: %@, TTL: %ld>",
+            self.event, self.deviceID, self.data, self.time, (long)self.ttl];
 }
+
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Pod/Classes/SDK/SparkUser.h
+++ b/Pod/Classes/SDK/SparkUser.h
@@ -19,16 +19,19 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface SparkUser : NSObject
+
 /**
  *  User name, should be a valid email address
  */
-@property (nonatomic, strong, readonly) NSString *user;
+@property (nonatomic, strong, nullable, readonly) NSString *user;
 
 /**
  *  Password string
  */
-@property (nonatomic, strong, readonly) NSString *password;
+@property (nonatomic, strong, nullable, readonly) NSString *password;
 
 /**
  *  Initialize SparkUser class with new credentials and store session in keychain
@@ -55,3 +58,5 @@
 -(void)removeSession;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Pod/Classes/SDK/SparkUser.m
+++ b/Pod/Classes/SDK/SparkUser.m
@@ -11,10 +11,13 @@
 
 NSString *const kSparkCredentialsKeychainEntry = @"io.spark.api.Keychain.Credentials";
 
+NS_ASSUME_NONNULL_BEGIN
 
 @interface SparkUser()
-@property (nonatomic, strong) NSString *user;
-@property (nonatomic, strong) NSString *password;
+
+@property (nonatomic, nullable, strong, readwrite) NSString *user;
+@property (nonatomic, nullable, strong, readwrite) NSString *password;
+
 @end
 
 @implementation SparkUser
@@ -68,3 +71,5 @@ NSString *const kSparkCredentialsKeychainEntry = @"io.spark.api.Keychain.Credent
 }
 
 @end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
I was working on a little experimental app using the spark SDK and Swift and I kept running into problems where Swift's optional system would assume a value was nonnull when its nullability was actually important. Most notably were the error objects used in the completion callbacks. So, I went through the pod and spec'd out nullability on it. Hope this helps!
